### PR TITLE
fix(admin): bootstrap flow, workspace owner access, onboarding checklist

### DIFF
--- a/assets/css/app.css
+++ b/assets/css/app.css
@@ -4184,3 +4184,67 @@ a {
     padding-left: 16px;
   }
 }
+
+/* ── Onboarding Checklist ─────────────────────────────── */
+
+.sa-onboarding-card {
+  background: var(--sa-white);
+  border: 1px solid #bfdbfe;
+  border-left: 4px solid #3b82f6;
+}
+
+.sa-onboarding-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.sa-onboarding-header h2 {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sa-onboarding-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 10px;
+}
+
+.sa-onboarding-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  background: #f8fafc;
+  border: 1px solid var(--sa-border);
+}
+
+.sa-onboarding-item.sa-onboarding-done {
+  opacity: 0.65;
+}
+
+.sa-onboarding-icon {
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+}
+
+.sa-onboarding-label {
+  flex: 1;
+  font-weight: 500;
+  color: var(--sa-slate);
+}
+
+.sa-onboarding-status {
+  font-size: 0.85rem;
+}
+
+.sa-btn-sm {
+  font-size: 0.8rem;
+  padding: 4px 10px;
+}

--- a/lib/assistant/accounts.ex
+++ b/lib/assistant/accounts.ex
@@ -43,8 +43,8 @@ defmodule Assistant.Accounts do
   a matching allowlist entry.
   """
   def bootstrap_admin_access(%SettingsUser{} = settings_user) do
-    if admin_bootstrap_available?() do
-      Repo.transact(fn ->
+    Repo.transact(fn ->
+      if admin_bootstrap_available?() do
         with {:ok, _entry} <-
                upsert_settings_user_allowlist_entry(
                  %{
@@ -62,10 +62,10 @@ defmodule Assistant.Accounts do
         else
           {:error, _} = error -> error
         end
-      end)
-    else
-      {:error, :bootstrap_closed}
-    end
+      else
+        {:error, :bootstrap_closed}
+      end
+    end)
   end
 
   @doc """

--- a/lib/assistant/accounts.ex
+++ b/lib/assistant/accounts.ex
@@ -539,6 +539,15 @@ defmodule Assistant.Accounts do
   end
 
   @doc """
+  Sets `onboarding_dismissed_at` to dismiss the getting-started checklist.
+  """
+  def update_settings_user_onboarding_dismissed(%SettingsUser{} = settings_user, %DateTime{} = at) do
+    settings_user
+    |> Ecto.Changeset.change(onboarding_dismissed_at: at)
+    |> Repo.update()
+  end
+
+  @doc """
   Updates the per-user model default overrides for a settings_user.
   """
   def update_settings_user_model_defaults(%SettingsUser{} = settings_user, defaults)

--- a/lib/assistant/accounts/scope.ex
+++ b/lib/assistant/accounts/scope.ex
@@ -44,4 +44,17 @@ defmodule Assistant.Accounts.Scope do
   end
 
   def for_settings_user(nil), do: nil
+
+  @doc """
+  Returns true if the scope holder can configure workspace integrations.
+
+  Admins always can. Non-admins can if their billing_role is "owner" or "admin".
+  """
+  def can_configure_integrations?(%__MODULE__{admin?: true}), do: true
+
+  def can_configure_integrations?(%__MODULE__{settings_user: %{billing_role: role}})
+      when role in ["owner", "admin"],
+      do: true
+
+  def can_configure_integrations?(_), do: false
 end

--- a/lib/assistant/accounts/settings_user.ex
+++ b/lib/assistant/accounts/settings_user.ex
@@ -28,6 +28,7 @@ defmodule Assistant.Accounts.SettingsUser do
     field :openai_auth_type, :string
     field :disabled_at, :utc_datetime
     field :billing_role, :string, default: "member"
+    field :onboarding_dismissed_at, :utc_datetime
 
     belongs_to :user, Assistant.Schemas.User
     belongs_to :billing_account, Assistant.Schemas.BillingAccount

--- a/lib/assistant_web/components/settings_page/admin.ex
+++ b/lib/assistant_web/components/settings_page/admin.ex
@@ -36,16 +36,14 @@ defmodule AssistantWeb.Components.SettingsPage.Admin do
       </.button>
     </section>
 
-    <section :if={@current_scope.settings_user.is_admin} class="space-y-6">
+    <section
+      :if={Assistant.Accounts.Scope.can_configure_integrations?(@current_scope)}
+      class="space-y-6"
+    >
       <nav class="sa-admin-tabs" role="tablist">
         <button
           :for={
-            {tab_id, tab_label} <- [
-              {"integrations", "Integrations"},
-              {"models", "Models"},
-              {"users", "Users"},
-              {"policies", "Policies"}
-            ]
+            {tab_id, tab_label} <- admin_tabs_for(@current_scope)
           }
           type="button"
           role="tab"
@@ -109,7 +107,7 @@ defmodule AssistantWeb.Components.SettingsPage.Admin do
         </div>
       </div>
 
-      <div :if={@admin_tab == "models"}>
+      <div :if={@admin_tab == "models" and @current_scope.admin?}>
         <div class="space-y-6">
           <.admin_model_providers {assigns} />
           <.admin_role_defaults {assigns} />
@@ -117,11 +115,11 @@ defmodule AssistantWeb.Components.SettingsPage.Admin do
         </div>
       </div>
 
-      <div :if={@admin_tab == "policies"}>
+      <div :if={@admin_tab == "policies" and @current_scope.admin?}>
         <.policies_section {assigns} />
       </div>
 
-      <div :if={@admin_tab == "users"} class="space-y-6">
+      <div :if={@admin_tab == "users" and @current_scope.admin?} class="space-y-6">
         <.user_detail_section
           :if={@current_admin_user}
           user={@current_admin_user}
@@ -539,6 +537,19 @@ defmodule AssistantWeb.Components.SettingsPage.Admin do
   end
 
   defp managed_integration_catalog(_), do: []
+
+  defp admin_tabs_for(%{admin?: true}) do
+    [
+      {"integrations", "Integrations"},
+      {"models", "Models"},
+      {"users", "Users"},
+      {"policies", "Policies"}
+    ]
+  end
+
+  defp admin_tabs_for(_scope) do
+    [{"integrations", "Integrations"}]
+  end
 
   defp google_chat_service_account_fields do
     [

--- a/lib/assistant_web/components/settings_page/helpers.ex
+++ b/lib/assistant_web/components/settings_page/helpers.ex
@@ -17,15 +17,16 @@ defmodule AssistantWeb.Components.SettingsPage.Helpers do
 
   @doc """
   Returns nav items filtered by user role and scope privileges.
-  Admin tab only shown to admins. Other sections gated by scope visibility.
+  Admin tab shown to admins and workspace owners who can configure integrations.
+  Other sections gated by scope visibility.
   """
   def nav_items_for(current_scope) when is_map(current_scope) do
-    is_admin = current_scope.admin?
+    alias Assistant.Accounts.Scope
 
     nav_items()
     |> Enum.filter(fn {section, _label} ->
       case section do
-        "admin" -> is_admin
+        "admin" -> Scope.can_configure_integrations?(current_scope)
         _ -> scope_visible?(section_scope(section), current_scope)
       end
     end)

--- a/lib/assistant_web/components/settings_page/onboarding.ex
+++ b/lib/assistant_web/components/settings_page/onboarding.ex
@@ -1,0 +1,80 @@
+defmodule AssistantWeb.Components.SettingsPage.Onboarding do
+  @moduledoc false
+
+  use AssistantWeb, :html
+
+  @doc """
+  Renders a "Getting Started" onboarding checklist card.
+
+  Expects assigns:
+    - `checklist_items`: list of `%{label: str, complete?: bool, link: str, action: str}`
+    - `all_complete?`: boolean — true when every item is done
+    - `onboarding_dismissed?`: boolean — true when user manually dismissed
+  """
+  def onboarding_checklist(assigns) do
+    ~H"""
+    <article
+      :if={!@onboarding_dismissed? && !@all_complete?}
+      class="sa-card sa-onboarding-card"
+      aria-label="Getting started checklist"
+    >
+      <div class="sa-onboarding-header">
+        <h2>
+          <.icon name="hero-rocket-launch" class="h-5 w-5" /> Getting Started
+        </h2>
+        <button
+          type="button"
+          class="sa-btn secondary sa-btn-sm"
+          phx-click="dismiss_onboarding"
+          aria-label="Dismiss getting started checklist"
+        >
+          Dismiss
+        </button>
+      </div>
+
+      <p class="sa-muted">
+        Complete these steps to set up your workspace.
+      </p>
+
+      <ul class="sa-onboarding-list" role="list">
+        <li
+          :for={item <- @checklist_items}
+          class={"sa-onboarding-item #{if item.complete?, do: "sa-onboarding-done"}"}
+          aria-label={item.label}
+          aria-checked={"#{item.complete?}"}
+          role="listitem"
+        >
+          <span class="sa-onboarding-icon">
+            <.icon
+              :if={item.complete?}
+              name="hero-check-circle"
+              class="h-5 w-5 text-green-500"
+            />
+            <.icon
+              :if={!item.complete?}
+              name="hero-minus-circle"
+              class="h-5 w-5 text-zinc-300"
+            />
+          </span>
+
+          <span class="sa-onboarding-label">
+            {item.label}
+          </span>
+
+          <.link
+            :if={!item.complete?}
+            navigate={item.link}
+            class="sa-btn secondary sa-btn-sm"
+          >
+            {item.action}
+          </.link>
+
+          <span :if={item.complete?} class="sa-muted sa-onboarding-status">
+            Done
+          </span>
+        </li>
+      </ul>
+    </article>
+    """
+  end
+end

--- a/lib/assistant_web/components/settings_page/profile.ex
+++ b/lib/assistant_web/components/settings_page/profile.ex
@@ -5,10 +5,17 @@ defmodule AssistantWeb.Components.SettingsPage.Profile do
 
   alias Assistant.Deployment
   alias AssistantWeb.Components.SettingsPage.Helpers
+  alias AssistantWeb.Components.SettingsPage.Onboarding
 
   def profile_section(assigns) do
     ~H"""
     <section class="sa-section-stack">
+      <Onboarding.onboarding_checklist
+        checklist_items={@onboarding_checklist_items}
+        all_complete?={@onboarding_all_complete?}
+        onboarding_dismissed?={@onboarding_dismissed?}
+      />
+
       <article class="sa-card">
         <h2>Account</h2>
         <p class="sa-muted">Manage your profile and account settings.</p>

--- a/lib/assistant_web/live/settings_live/events.ex
+++ b/lib/assistant_web/live/settings_live/events.ex
@@ -1381,6 +1381,19 @@ defmodule AssistantWeb.SettingsLive.Events do
     Profile.save_profile(socket, params, flash?: true)
   end
 
+  def handle_event("dismiss_onboarding", _params, socket) do
+    settings_user = Context.current_settings_user(socket)
+    now = DateTime.utc_now(:second)
+
+    case Accounts.update_settings_user_onboarding_dismissed(settings_user, now) do
+      {:ok, _updated} ->
+        {:noreply, assign(socket, :onboarding_dismissed?, true)}
+
+      {:error, _changeset} ->
+        {:noreply, put_flash(socket, :error, "Could not dismiss checklist.")}
+    end
+  end
+
   def handle_event("autosave_profile", %{"profile" => params}, socket) do
     Profile.save_profile(socket, params, flash?: false)
   end

--- a/lib/assistant_web/live/settings_live/events.ex
+++ b/lib/assistant_web/live/settings_live/events.ex
@@ -1388,15 +1388,20 @@ defmodule AssistantWeb.SettingsLive.Events do
   end
 
   def handle_event("dismiss_onboarding", _params, socket) do
-    settings_user = Context.current_settings_user(socket)
-    now = DateTime.utc_now(:second)
+    case Context.current_settings_user(socket) do
+      nil ->
+        {:noreply, socket}
 
-    case Accounts.update_settings_user_onboarding_dismissed(settings_user, now) do
-      {:ok, _updated} ->
-        {:noreply, assign(socket, :onboarding_dismissed?, true)}
+      settings_user ->
+        now = DateTime.utc_now(:second)
 
-      {:error, _changeset} ->
-        {:noreply, put_flash(socket, :error, "Could not dismiss checklist.")}
+        case Accounts.update_settings_user_onboarding_dismissed(settings_user, now) do
+          {:ok, _updated} ->
+            {:noreply, assign(socket, :onboarding_dismissed?, true)}
+
+          {:error, _changeset} ->
+            {:noreply, put_flash(socket, :error, "Could not dismiss checklist.")}
+        end
     end
   end
 

--- a/lib/assistant_web/live/settings_live/events.ex
+++ b/lib/assistant_web/live/settings_live/events.ex
@@ -46,16 +46,22 @@ defmodule AssistantWeb.SettingsLive.Events do
 
   def handle_event("switch_admin_tab", %{"tab" => tab}, socket)
       when tab in ~w(integrations models users policies) do
-    socket = assign(socket, :admin_tab, tab)
+    is_admin = socket.assigns.current_scope.admin?
 
-    socket =
-      if tab == "policies" do
-        Loaders.load_admin_policies(socket)
-      else
-        socket
-      end
+    if tab != "integrations" and not is_admin do
+      {:noreply, socket}
+    else
+      socket = assign(socket, :admin_tab, tab)
 
-    {:noreply, socket}
+      socket =
+        if tab == "policies" do
+          Loaders.load_admin_policies(socket)
+        else
+          socket
+        end
+
+      {:noreply, socket}
+    end
   end
 
   def handle_event("set_policy_preset", %{"preset" => preset}, socket) do

--- a/lib/assistant_web/live/settings_live/loaders.ex
+++ b/lib/assistant_web/live/settings_live/loaders.ex
@@ -282,7 +282,7 @@ defmodule AssistantWeb.SettingsLive.Loaders do
       true ->
         assign(socket,
           can_bootstrap_admin: can_bootstrap,
-          managed_scopes: Accounts.managed_access_scopes(),
+          managed_scopes: [],
           allowlist_form: to_form(%{}, as: "allowlist_entry"),
           allowlist_entries: [],
           admin_settings_users: [],
@@ -709,17 +709,20 @@ defmodule AssistantWeb.SettingsLive.Loaders do
 
   defp load_onboarding(socket) do
     settings_user = Context.current_settings_user(socket)
+    current_scope = socket.assigns[:current_scope]
+    can_configure? = Scope.can_configure_integrations?(current_scope)
 
     dismissed? = not is_nil(settings_user) and not is_nil(settings_user.onboarding_dismissed_at)
 
     admin_complete? = settings_user != nil and settings_user.is_admin == true
 
     llm_complete? =
-      settings_user != nil and
-        (present?(settings_user.openrouter_api_key) or
-           present?(settings_user.openai_api_key))
+      system_llm_key_configured?() or
+        (settings_user != nil and
+           (present?(settings_user.openrouter_api_key) or
+              present?(settings_user.openai_api_key)))
 
-    channel_complete? = channel_configured?()
+    channel_complete? = if can_configure?, do: channel_configured?(), else: true
 
     items = [
       %{
@@ -748,6 +751,11 @@ defmodule AssistantWeb.SettingsLive.Loaders do
     |> assign(:onboarding_checklist_items, items)
     |> assign(:onboarding_all_complete?, all_complete?)
     |> assign(:onboarding_dismissed?, dismissed?)
+  end
+
+  defp system_llm_key_configured? do
+    present?(Application.get_env(:assistant, :openrouter_api_key)) or
+      present?(Application.get_env(:assistant, :openai_api_key))
   end
 
   defp channel_configured? do

--- a/lib/assistant_web/live/settings_live/loaders.ex
+++ b/lib/assistant_web/live/settings_live/loaders.ex
@@ -6,6 +6,7 @@ defmodule AssistantWeb.SettingsLive.Loaders do
   require Logger
 
   alias Assistant.Accounts
+  alias Assistant.Accounts.Scope
   alias Assistant.Billing
   alias Assistant.Billing.StorageAccounting
   alias Assistant.Accounts.{SettingsUser, SettingsUserAllowlistEntry}
@@ -37,7 +38,7 @@ defmodule AssistantWeb.SettingsLive.Loaders do
   @policy_default_presets ["permissive", "default", "strict"]
 
   def load_section_data(socket, "profile"),
-    do: socket |> load_profile() |> load_orchestrator_prompt()
+    do: socket |> load_profile() |> load_orchestrator_prompt() |> load_onboarding()
 
   def load_section_data(socket, "workflows"), do: reload_workflows(socket)
   def load_section_data(socket, "analytics"), do: load_analytics(socket)
@@ -227,46 +228,68 @@ defmodule AssistantWeb.SettingsLive.Loaders do
 
   def load_admin(socket) do
     settings_user = Context.current_settings_user(socket)
+    current_scope = socket.assigns[:current_scope]
     can_bootstrap = Accounts.admin_bootstrap_available?()
+    is_admin = settings_user && settings_user.is_admin
 
-    if settings_user && settings_user.is_admin do
-      blank_form =
-        %SettingsUserAllowlistEntry{}
-        |> Accounts.change_settings_user_allowlist_entry(%{
-          active: true,
-          is_admin: false,
-          scopes: []
-        })
-        |> to_form(as: "allowlist_entry")
+    cond do
+      # Full admin: all data (users, models, integrations, allowlist)
+      is_admin ->
+        blank_form =
+          %SettingsUserAllowlistEntry{}
+          |> Accounts.change_settings_user_allowlist_entry(%{
+            active: true,
+            is_admin: false,
+            scopes: []
+          })
+          |> to_form(as: "allowlist_entry")
 
-      all_users = Accounts.list_settings_users_for_admin()
-      search = socket.assigns[:admin_user_search] || ""
+        all_users = Accounts.list_settings_users_for_admin()
+        search = socket.assigns[:admin_user_search] || ""
 
-      socket
-      |> assign(
-        managed_scopes: Accounts.managed_access_scopes(),
-        can_bootstrap_admin: can_bootstrap,
-        allowlist_form: blank_form,
-        allowlist_entries: Accounts.list_settings_user_allowlist_entries(),
-        admin_settings_users: Accounts.list_admin_settings_users(),
-        admin_users_with_keys: all_users,
-        filtered_admin_users: filter_admin_users(all_users, search),
-        integration_settings: IntegrationSettings.list_all()
-      )
-      |> load_admin_model_data()
-      |> load_models()
-      |> maybe_refresh_current_admin_user()
-    else
-      assign(socket,
-        can_bootstrap_admin: can_bootstrap,
-        managed_scopes: Accounts.managed_access_scopes(),
-        allowlist_form: to_form(%{}, as: "allowlist_entry"),
-        allowlist_entries: [],
-        admin_settings_users: [],
-        admin_users_with_keys: [],
-        filtered_admin_users: [],
-        integration_settings: []
-      )
+        socket
+        |> assign(
+          managed_scopes: Accounts.managed_access_scopes(),
+          can_bootstrap_admin: can_bootstrap,
+          allowlist_form: blank_form,
+          allowlist_entries: Accounts.list_settings_user_allowlist_entries(),
+          admin_settings_users: Accounts.list_admin_settings_users(),
+          admin_users_with_keys: all_users,
+          filtered_admin_users: filter_admin_users(all_users, search),
+          integration_settings: IntegrationSettings.list_all()
+        )
+        |> load_admin_model_data()
+        |> load_models()
+        |> maybe_refresh_current_admin_user()
+
+      # Workspace owner: integration settings + connection status only
+      Scope.can_configure_integrations?(current_scope) ->
+        socket
+        |> assign(
+          can_bootstrap_admin: can_bootstrap,
+          managed_scopes: [],
+          allowlist_form: to_form(%{}, as: "allowlist_entry"),
+          allowlist_entries: [],
+          admin_settings_users: [],
+          admin_users_with_keys: [],
+          filtered_admin_users: [],
+          integration_settings: IntegrationSettings.list_all()
+        )
+        |> load_workspace_enabled_groups()
+        |> load_connection_status()
+
+      # No access: minimal assigns for bootstrap display
+      true ->
+        assign(socket,
+          can_bootstrap_admin: can_bootstrap,
+          managed_scopes: Accounts.managed_access_scopes(),
+          allowlist_form: to_form(%{}, as: "allowlist_entry"),
+          allowlist_entries: [],
+          admin_settings_users: [],
+          admin_users_with_keys: [],
+          filtered_admin_users: [],
+          integration_settings: []
+        )
     end
   end
 
@@ -682,6 +705,56 @@ defmodule AssistantWeb.SettingsLive.Loaders do
     |> assign(:profile_form, to_form(profile, as: :profile))
     |> assign(:billing_summary, billing_snapshot.billing_summary)
     |> assign(:billing_storage, billing_storage)
+  end
+
+  defp load_onboarding(socket) do
+    settings_user = Context.current_settings_user(socket)
+
+    dismissed? = not is_nil(settings_user) and not is_nil(settings_user.onboarding_dismissed_at)
+
+    admin_complete? = settings_user != nil and settings_user.is_admin == true
+
+    llm_complete? =
+      settings_user != nil and
+        (present?(settings_user.openrouter_api_key) or
+           present?(settings_user.openai_api_key))
+
+    channel_complete? = channel_configured?()
+
+    items = [
+      %{
+        label: "Claim admin access",
+        complete?: admin_complete?,
+        link: "/settings/admin",
+        action: "Go to Admin"
+      },
+      %{
+        label: "Connect an LLM provider",
+        complete?: llm_complete?,
+        link: "/settings/apps",
+        action: "Connect"
+      },
+      %{
+        label: "Connect a messaging channel",
+        complete?: channel_complete?,
+        link: "/settings/apps",
+        action: "Connect"
+      }
+    ]
+
+    all_complete? = Enum.all?(items, & &1.complete?)
+
+    socket
+    |> assign(:onboarding_checklist_items, items)
+    |> assign(:onboarding_all_complete?, all_complete?)
+    |> assign(:onboarding_dismissed?, dismissed?)
+  end
+
+  defp channel_configured? do
+    Enum.any?(
+      ~w(telegram_bot_token discord_bot_token slack_bot_token)a,
+      fn key -> present?(IntegrationSettings.get(key)) end
+    )
   end
 
   defp billing_storage_summary(%{storage_policy: policy, billing_account: billing_account}) do

--- a/lib/assistant_web/live/settings_live/loaders.ex
+++ b/lib/assistant_web/live/settings_live/loaders.ex
@@ -464,9 +464,9 @@ defmodule AssistantWeb.SettingsLive.Loaders do
   end
 
   def load_admin_integration_settings(socket, integration_group) do
-    settings_user = Context.current_settings_user(socket)
+    current_scope = socket.assigns[:current_scope]
 
-    if settings_user && settings_user.is_admin do
+    if Scope.can_configure_integrations?(current_scope) do
       assign(socket, :integration_settings, integration_settings_for_group(integration_group))
     else
       assign(socket, :integration_settings, [])

--- a/lib/assistant_web/live/settings_live/state.ex
+++ b/lib/assistant_web/live/settings_live/state.ex
@@ -129,6 +129,9 @@ defmodule AssistantWeb.SettingsLive.State do
     |> assign(:telegram_connect_url, nil)
     |> assign(:telegram_bot_username, nil)
     |> assign(:telegram_connect_expires_at, nil)
+    |> assign(:onboarding_checklist_items, [])
+    |> assign(:onboarding_all_complete?, false)
+    |> assign(:onboarding_dismissed?, true)
     |> Loaders.load_profile()
     |> Loaders.load_orchestrator_prompt()
   end

--- a/lib/assistant_web/live/settings_live/state.ex
+++ b/lib/assistant_web/live/settings_live/state.ex
@@ -4,6 +4,8 @@ defmodule AssistantWeb.SettingsLive.State do
   import Phoenix.Component, only: [assign: 3, assign_new: 3, to_form: 2]
   import Phoenix.LiveView, only: [push_navigate: 2, put_flash: 3]
 
+  alias Assistant.Accounts
+  alias Assistant.Accounts.Scope
   alias AssistantWeb.Components.SettingsPage.Helpers, as: PageHelpers
   alias AssistantWeb.SettingsLive.Data
   alias AssistantWeb.SettingsLive.Loaders
@@ -146,18 +148,11 @@ defmodule AssistantWeb.SettingsLive.State do
 
   defp handle_section(socket, params) do
     section = Data.normalize_section(Map.get(params, "section", "profile"))
-
-    is_admin =
-      case socket.assigns[:current_scope] do
-        %{settings_user: %{is_admin: true}} -> true
-        _ -> false
-      end
-
     current_scope = socket.assigns[:current_scope]
     section_scope = section_scope_name(section)
 
     cond do
-      section == "admin" and not is_admin ->
+      section == "admin" and not admin_section_allowed?(current_scope) ->
         socket
         |> put_flash(:error, "You do not have permission to access admin.")
         |> push_navigate(to: "/settings")
@@ -203,15 +198,10 @@ defmodule AssistantWeb.SettingsLive.State do
 
   defp handle_admin_integration(socket, params) do
     integration_group = Map.get(params, "integration_group")
-
-    is_admin =
-      case socket.assigns[:current_scope] do
-        %{settings_user: %{is_admin: true}} -> true
-        _ -> false
-      end
+    current_scope = socket.assigns[:current_scope]
 
     cond do
-      not is_admin ->
+      not admin_section_allowed?(current_scope) ->
         socket
         |> put_flash(:error, "You do not have permission to access admin.")
         |> push_navigate(to: "/settings")
@@ -235,4 +225,11 @@ defmodule AssistantWeb.SettingsLive.State do
   end
 
   defp section_scope_name(section), do: PageHelpers.section_scope(section)
+
+  # Allow access to admin section when:
+  # 1. Bootstrap exception: no admins exist yet (self-closing gate)
+  # 2. Workspace owner/admin: user can configure integrations
+  defp admin_section_allowed?(current_scope) do
+    Accounts.admin_bootstrap_available?() or Scope.can_configure_integrations?(current_scope)
+  end
 end

--- a/priv/repo/migrations/20260402180000_add_onboarding_dismissed_at_to_settings_users.exs
+++ b/priv/repo/migrations/20260402180000_add_onboarding_dismissed_at_to_settings_users.exs
@@ -1,0 +1,9 @@
+defmodule Assistant.Repo.Migrations.AddOnboardingDismissedAtToSettingsUsers do
+  use Ecto.Migration
+
+  def change do
+    alter table(:settings_users) do
+      add :onboarding_dismissed_at, :utc_datetime, null: true
+    end
+  end
+end

--- a/test/assistant/accounts/scope_test.exs
+++ b/test/assistant/accounts/scope_test.exs
@@ -1,0 +1,96 @@
+defmodule Assistant.Accounts.ScopeTest do
+  use Assistant.DataCase, async: true
+
+  alias Assistant.Accounts.Scope
+
+  describe "can_configure_integrations?/1" do
+    test "returns true when scope has admin? true" do
+      scope = %Scope{admin?: true, settings_user: %{billing_role: "member"}}
+      assert Scope.can_configure_integrations?(scope)
+    end
+
+    test "returns true when billing_role is owner and not admin" do
+      scope = %Scope{admin?: false, settings_user: %{billing_role: "owner"}}
+      assert Scope.can_configure_integrations?(scope)
+    end
+
+    test "returns true when billing_role is admin and not admin" do
+      scope = %Scope{admin?: false, settings_user: %{billing_role: "admin"}}
+      assert Scope.can_configure_integrations?(scope)
+    end
+
+    test "returns false when billing_role is member and not admin" do
+      scope = %Scope{admin?: false, settings_user: %{billing_role: "member"}}
+      refute Scope.can_configure_integrations?(scope)
+    end
+
+    test "returns false when billing_role is nil and not admin" do
+      scope = %Scope{admin?: false, settings_user: %{billing_role: nil}}
+      refute Scope.can_configure_integrations?(scope)
+    end
+
+    test "returns false for nil scope" do
+      refute Scope.can_configure_integrations?(nil)
+    end
+
+    test "returns false when settings_user is nil" do
+      scope = %Scope{admin?: false, settings_user: nil}
+      refute Scope.can_configure_integrations?(scope)
+    end
+
+    test "admin flag takes precedence over non-qualifying billing_role" do
+      scope = %Scope{admin?: true, settings_user: %{billing_role: nil}}
+      assert Scope.can_configure_integrations?(scope)
+    end
+  end
+
+  describe "can_configure_integrations?/1 with DB-backed scope" do
+    import Assistant.AccountsFixtures
+
+    test "returns true for scope built from admin user" do
+      admin = admin_settings_user_fixture()
+      scope = Scope.for_settings_user(admin)
+      assert Scope.can_configure_integrations?(scope)
+    end
+
+    test "returns false for scope built from regular user (default member role)" do
+      user = settings_user_fixture()
+      scope = Scope.for_settings_user(user)
+      refute Scope.can_configure_integrations?(scope)
+    end
+
+    test "returns true for scope built from user with billing_role owner" do
+      user = settings_user_fixture()
+
+      user =
+        user
+        |> Ecto.Changeset.change(billing_role: "owner")
+        |> Assistant.Repo.update!()
+
+      scope = Scope.for_settings_user(user)
+      assert Scope.can_configure_integrations?(scope)
+    end
+  end
+
+  describe "for_settings_user/1" do
+    import Assistant.AccountsFixtures
+
+    test "sets admin? to true when is_admin is true" do
+      settings_user = settings_user_fixture() |> Map.put(:is_admin, true) |> Map.put(:access_scopes, [])
+      scope = Scope.for_settings_user(settings_user)
+      assert scope.admin? == true
+      assert "admin" in scope.privileges
+    end
+
+    test "sets admin? to false when is_admin is false" do
+      settings_user = settings_user_fixture() |> Map.put(:is_admin, false) |> Map.put(:access_scopes, [])
+      scope = Scope.for_settings_user(settings_user)
+      assert scope.admin? == false
+      refute "admin" in scope.privileges
+    end
+
+    test "returns nil for nil input" do
+      assert Scope.for_settings_user(nil) == nil
+    end
+  end
+end

--- a/test/assistant_web/components/settings_page/helpers_test.exs
+++ b/test/assistant_web/components/settings_page/helpers_test.exs
@@ -1,0 +1,74 @@
+defmodule AssistantWeb.Components.SettingsPage.HelpersTest do
+  use Assistant.DataCase, async: true
+
+  alias Assistant.Accounts.Scope
+  alias AssistantWeb.Components.SettingsPage.Helpers
+
+  describe "nav_items_for/1 with scope struct" do
+    test "includes admin tab for admin scope" do
+      scope = %Scope{admin?: true, settings_user: %{billing_role: "member"}, privileges: ["admin"]}
+      items = Helpers.nav_items_for(scope)
+      sections = Enum.map(items, &elem(&1, 0))
+
+      assert "admin" in sections
+    end
+
+    test "includes admin tab for workspace owner scope" do
+      scope = %Scope{admin?: false, settings_user: %{billing_role: "owner"}, privileges: []}
+      items = Helpers.nav_items_for(scope)
+      sections = Enum.map(items, &elem(&1, 0))
+
+      assert "admin" in sections
+    end
+
+    test "includes admin tab for workspace billing admin scope" do
+      scope = %Scope{admin?: false, settings_user: %{billing_role: "admin"}, privileges: []}
+      items = Helpers.nav_items_for(scope)
+      sections = Enum.map(items, &elem(&1, 0))
+
+      assert "admin" in sections
+    end
+
+    test "excludes admin tab for regular member scope" do
+      scope = %Scope{admin?: false, settings_user: %{billing_role: "member"}, privileges: []}
+      items = Helpers.nav_items_for(scope)
+      sections = Enum.map(items, &elem(&1, 0))
+
+      refute "admin" in sections
+    end
+
+    test "excludes admin tab for nil billing_role scope" do
+      scope = %Scope{admin?: false, settings_user: %{billing_role: nil}, privileges: []}
+      items = Helpers.nav_items_for(scope)
+      sections = Enum.map(items, &elem(&1, 0))
+
+      refute "admin" in sections
+    end
+
+    test "always includes core sections" do
+      scope = %Scope{admin?: false, settings_user: %{billing_role: "member"}, privileges: []}
+      items = Helpers.nav_items_for(scope)
+      sections = Enum.map(items, &elem(&1, 0))
+
+      assert "profile" in sections
+      assert "workspace" in sections
+      assert "help" in sections
+    end
+  end
+
+  describe "nav_items_for/1 with boolean" do
+    test "includes admin tab when true" do
+      items = Helpers.nav_items_for(true)
+      sections = Enum.map(items, &elem(&1, 0))
+
+      assert "admin" in sections
+    end
+
+    test "excludes admin tab when false" do
+      items = Helpers.nav_items_for(false)
+      sections = Enum.map(items, &elem(&1, 0))
+
+      refute "admin" in sections
+    end
+  end
+end

--- a/test/assistant_web/live/settings_live/admin_access_onboarding_test.exs
+++ b/test/assistant_web/live/settings_live/admin_access_onboarding_test.exs
@@ -6,6 +6,7 @@ defmodule AssistantWeb.SettingsLive.AdminAccessOnboardingTest do
 
   alias Assistant.Accounts
   alias Assistant.Accounts.SettingsUser
+  alias Assistant.IntegrationSettings
   alias Assistant.Repo
 
   # ─────────────────────────────────────────────────
@@ -281,10 +282,11 @@ defmodule AssistantWeb.SettingsLive.AdminAccessOnboardingTest do
       user = settings_user_fixture()
       conn = log_in_settings_user(conn, user)
 
-      {:ok, lv, html} = live(conn, ~p"/settings")
+      {:ok, _lv, html} = live(conn, ~p"/settings")
 
-      # Before claiming, admin item should be incomplete
+      # Before claiming, admin item should be incomplete — shows action link, no "Done"
       assert html =~ "Claim admin access"
+      assert html =~ "Go to Admin"
 
       # Navigate to admin and claim
       {:ok, lv, _html} = live(conn, ~p"/settings/admin")
@@ -293,9 +295,63 @@ defmodule AssistantWeb.SettingsLive.AdminAccessOnboardingTest do
       # Navigate back to profile to check checklist
       {:ok, _lv, html} = live(conn, ~p"/settings")
 
-      # The admin item should now show as complete (check icon rendered)
-      # "Claim admin access" should still appear but with "Done" status
+      # The admin item should now show as complete with "Done" status and check icon
       assert html =~ "Claim admin access"
+      assert html =~ "sa-onboarding-done"
+      assert html =~ "Done"
+      assert html =~ "hero-check-circle"
+    end
+
+    test "checklist shows LLM item as complete when user has openrouter key", %{conn: conn} do
+      user = settings_user_fixture()
+
+      user
+      |> Ecto.Changeset.change(%{openrouter_api_key: "sk-or-test-key"})
+      |> Repo.update!()
+
+      conn = log_in_settings_user(conn, user)
+      {:ok, _lv, html} = live(conn, ~p"/settings")
+
+      assert html =~ "Getting Started"
+      # LLM item should show as complete
+      assert html =~ "Connect an LLM provider"
+      assert html =~ "Done"
+    end
+
+    test "checklist shows channel item as complete when a channel is configured", %{conn: conn} do
+      user = settings_user_fixture()
+      {:ok, _} = IntegrationSettings.put(:telegram_bot_token, "test-bot-token-123")
+
+      conn = log_in_settings_user(conn, user)
+      {:ok, _lv, html} = live(conn, ~p"/settings")
+
+      assert html =~ "Getting Started"
+      # Channel item should show as complete
+      assert html =~ "Connect a messaging channel"
+      assert html =~ "Done"
+    end
+
+    test "checklist auto-hides when all items are complete", %{conn: conn} do
+      user = settings_user_fixture()
+
+      # Complete admin: claim bootstrap
+      make_admin(user)
+
+      # Complete LLM: set openrouter key
+      user =
+        user
+        |> Ecto.Changeset.change(%{openrouter_api_key: "sk-or-test-key"})
+        |> Repo.update!()
+
+      # Complete channel: configure telegram
+      {:ok, _} = IntegrationSettings.put(:telegram_bot_token, "test-bot-token-123")
+
+      conn = log_in_settings_user(conn, user)
+      {:ok, _lv, html} = live(conn, ~p"/settings")
+
+      # Checklist should NOT render when all items are complete
+      refute html =~ "Getting Started"
+      refute html =~ "sa-onboarding-card"
     end
   end
 

--- a/test/assistant_web/live/settings_live/admin_access_onboarding_test.exs
+++ b/test/assistant_web/live/settings_live/admin_access_onboarding_test.exs
@@ -1,0 +1,337 @@
+defmodule AssistantWeb.SettingsLive.AdminAccessOnboardingTest do
+  use AssistantWeb.ConnCase, async: false
+
+  import Phoenix.LiveViewTest
+  import Assistant.AccountsFixtures
+
+  alias Assistant.Accounts
+  alias Assistant.Accounts.SettingsUser
+  alias Assistant.Repo
+
+  # ─────────────────────────────────────────────────
+  # Helpers
+  # ─────────────────────────────────────────────────
+
+  defp make_admin(settings_user) do
+    {:ok, admin} = Accounts.bootstrap_admin_access(settings_user)
+    admin
+  end
+
+  defp set_billing_role(settings_user, role) do
+    settings_user
+    |> Ecto.Changeset.change(billing_role: role)
+    |> Repo.update!()
+  end
+
+  # ─────────────────────────────────────────────────
+  # Route guard: admin section access
+  # ─────────────────────────────────────────────────
+
+  describe "admin route guard — bootstrap exception" do
+    test "non-admin CAN access admin section when no admins exist (bootstrap available)", %{conn: conn} do
+      user = settings_user_fixture()
+      conn = log_in_settings_user(conn, user)
+
+      # No admins exist yet, bootstrap should be available
+      assert Accounts.admin_bootstrap_available?()
+
+      {:ok, _lv, html} = live(conn, ~p"/settings/admin")
+
+      assert html =~ "Initial Admin Bootstrap"
+      assert html =~ "Claim Admin Access"
+    end
+
+    test "non-admin BLOCKED from admin section when bootstrap NOT available (admin exists)", %{conn: conn} do
+      # Create an admin first to close the bootstrap gate
+      admin = settings_user_fixture()
+      make_admin(admin)
+
+      # Now create a regular user with member billing_role
+      regular = settings_user_fixture()
+      conn = log_in_settings_user(conn, regular)
+
+      {:ok, _lv, html} = live(conn, ~p"/settings/admin")
+
+      # Should be redirected to /settings with flash
+      assert html =~ "You do not have permission to access admin"
+    end
+  end
+
+  describe "admin route guard — workspace owner access" do
+    setup %{conn: conn} do
+      # Create an admin first to close bootstrap gate
+      admin = settings_user_fixture()
+      make_admin(admin)
+
+      %{conn: conn, admin: admin}
+    end
+
+    test "workspace owner (billing_role: owner) CAN access admin section", %{conn: conn} do
+      owner = settings_user_fixture() |> set_billing_role("owner")
+      conn = log_in_settings_user(conn, owner)
+
+      {:ok, _lv, html} = live(conn, ~p"/settings/admin")
+
+      # Owner should see the Integrations tab
+      assert html =~ "Integrations"
+    end
+
+    test "workspace admin (billing_role: admin) CAN access admin section", %{conn: conn} do
+      billing_admin = settings_user_fixture() |> set_billing_role("admin")
+      conn = log_in_settings_user(conn, billing_admin)
+
+      {:ok, _lv, html} = live(conn, ~p"/settings/admin")
+
+      assert html =~ "Integrations"
+    end
+
+    test "regular member (billing_role: member) CANNOT access admin section", %{conn: conn} do
+      member = settings_user_fixture() |> set_billing_role("member")
+      conn = log_in_settings_user(conn, member)
+
+      {:ok, _lv, html} = live(conn, ~p"/settings/admin")
+
+      assert html =~ "You do not have permission to access admin"
+    end
+  end
+
+  # ─────────────────────────────────────────────────
+  # Admin tab gating: workspace owners see only Integrations
+  # ─────────────────────────────────────────────────
+
+  describe "admin tab visibility" do
+    setup %{conn: conn} do
+      admin = settings_user_fixture()
+      make_admin(admin)
+
+      %{conn: conn, admin: admin}
+    end
+
+    test "admin sees all tabs (Integrations, Models, Users, Policies)", %{conn: conn, admin: admin} do
+      conn = log_in_settings_user(conn, admin)
+      {:ok, _lv, html} = live(conn, ~p"/settings/admin")
+
+      assert html =~ "Integrations"
+      assert html =~ "Models"
+      assert html =~ "Users"
+      assert html =~ "Policies"
+    end
+
+    test "workspace owner sees only Integrations tab", %{conn: conn} do
+      owner = settings_user_fixture() |> set_billing_role("owner")
+      conn = log_in_settings_user(conn, owner)
+
+      {:ok, _lv, html} = live(conn, ~p"/settings/admin")
+
+      assert html =~ "Integrations"
+      # Should NOT see admin-only tabs
+      refute html =~ ~r/<button[^>]*>Models<\/button>/
+      refute html =~ ~r/<button[^>]*>Users<\/button>/
+      refute html =~ ~r/<button[^>]*>Policies<\/button>/
+    end
+
+    test "workspace owner cannot switch to models tab", %{conn: conn} do
+      owner = settings_user_fixture() |> set_billing_role("owner")
+      conn = log_in_settings_user(conn, owner)
+
+      {:ok, lv, _html} = live(conn, ~p"/settings/admin")
+
+      # Even if they somehow try to switch to models tab, the content is gated
+      html = render_click(lv, "switch_admin_tab", %{"tab" => "models"})
+
+      # Models content is gated by `@current_scope.admin?`
+      refute html =~ "Model Providers"
+      refute html =~ "Role Defaults"
+    end
+
+    test "workspace owner cannot switch to users tab", %{conn: conn} do
+      owner = settings_user_fixture() |> set_billing_role("owner")
+      conn = log_in_settings_user(conn, owner)
+
+      {:ok, lv, _html} = live(conn, ~p"/settings/admin")
+      html = render_click(lv, "switch_admin_tab", %{"tab" => "users"})
+
+      refute html =~ "User Management"
+    end
+  end
+
+  # ─────────────────────────────────────────────────
+  # Nav items: Admin tab visibility in sidebar
+  # ─────────────────────────────────────────────────
+
+  describe "sidebar nav visibility" do
+    setup %{conn: conn} do
+      admin = settings_user_fixture()
+      make_admin(admin)
+
+      %{conn: conn, admin: admin}
+    end
+
+    test "admin sees Admin nav item", %{conn: conn, admin: admin} do
+      conn = log_in_settings_user(conn, admin)
+      {:ok, _lv, html} = live(conn, ~p"/settings")
+
+      assert html =~ "Admin"
+    end
+
+    test "workspace owner sees Admin nav item", %{conn: conn} do
+      owner = settings_user_fixture() |> set_billing_role("owner")
+      conn = log_in_settings_user(conn, owner)
+
+      {:ok, _lv, html} = live(conn, ~p"/settings")
+
+      assert html =~ "Admin"
+    end
+
+    test "regular member does NOT see Admin nav item", %{conn: conn} do
+      member = settings_user_fixture() |> set_billing_role("member")
+      conn = log_in_settings_user(conn, member)
+
+      {:ok, _lv, html} = live(conn, ~p"/settings")
+
+      # The sidebar renders admin as a link with href /settings/admin
+      refute html =~ ~s|href="/settings/admin"|
+    end
+  end
+
+  # ─────────────────────────────────────────────────
+  # Bootstrap claim flow
+  # ─────────────────────────────────────────────────
+
+  describe "bootstrap claim" do
+    test "bootstrap claim creates allowlist entry and grants admin", %{conn: conn} do
+      user = settings_user_fixture()
+      conn = log_in_settings_user(conn, user)
+
+      assert Accounts.admin_bootstrap_available?()
+
+      {:ok, lv, _html} = live(conn, ~p"/settings/admin")
+      html = render_click(lv, "claim_bootstrap_admin", %{})
+
+      assert html =~ "Admin access claimed"
+
+      # Verify user is now admin
+      updated_user = Repo.get!(SettingsUser, user.id)
+      assert updated_user.is_admin == true
+
+      # Bootstrap should now be closed
+      refute Accounts.admin_bootstrap_available?()
+    end
+
+    test "second user bootstrap claim fails gracefully", %{conn: conn} do
+      # First user claims admin
+      first = settings_user_fixture()
+      make_admin(first)
+
+      # Second user tries — bootstrap gate is now closed
+      second = settings_user_fixture()
+      conn = log_in_settings_user(conn, second)
+
+      # Second user can't even access admin section now (redirected)
+      {:ok, _lv, html} = live(conn, ~p"/settings/admin")
+      assert html =~ "You do not have permission to access admin"
+    end
+  end
+
+  # ─────────────────────────────────────────────────
+  # Onboarding checklist
+  # ─────────────────────────────────────────────────
+
+  describe "onboarding checklist" do
+    test "checklist shows on profile for new non-admin user", %{conn: conn} do
+      user = settings_user_fixture()
+      conn = log_in_settings_user(conn, user)
+
+      {:ok, _lv, html} = live(conn, ~p"/settings")
+
+      assert html =~ "Getting Started"
+      assert html =~ "Claim admin access"
+      assert html =~ "Connect an LLM provider"
+      assert html =~ "Connect a messaging channel"
+    end
+
+    test "checklist hides when dismissed", %{conn: conn} do
+      user = settings_user_fixture()
+      conn = log_in_settings_user(conn, user)
+
+      {:ok, lv, _html} = live(conn, ~p"/settings")
+
+      # Dismiss the checklist
+      html = render_click(lv, "dismiss_onboarding", %{})
+
+      refute html =~ "Getting Started"
+
+      # Verify onboarding_dismissed_at is set in DB
+      updated_user = Repo.get!(SettingsUser, user.id)
+      assert updated_user.onboarding_dismissed_at != nil
+    end
+
+    test "checklist stays hidden after dismiss on page reload", %{conn: conn} do
+      user = settings_user_fixture()
+      now = DateTime.utc_now(:second)
+      {:ok, _} = Accounts.update_settings_user_onboarding_dismissed(user, now)
+
+      conn = log_in_settings_user(conn, user)
+      {:ok, _lv, html} = live(conn, ~p"/settings")
+
+      refute html =~ "Getting Started"
+    end
+
+    test "claim admin marks checklist item as complete", %{conn: conn} do
+      user = settings_user_fixture()
+      conn = log_in_settings_user(conn, user)
+
+      {:ok, lv, html} = live(conn, ~p"/settings")
+
+      # Before claiming, admin item should be incomplete
+      assert html =~ "Claim admin access"
+
+      # Navigate to admin and claim
+      {:ok, lv, _html} = live(conn, ~p"/settings/admin")
+      render_click(lv, "claim_bootstrap_admin", %{})
+
+      # Navigate back to profile to check checklist
+      {:ok, _lv, html} = live(conn, ~p"/settings")
+
+      # The admin item should now show as complete (check icon rendered)
+      # "Claim admin access" should still appear but with "Done" status
+      assert html =~ "Claim admin access"
+    end
+  end
+
+  # ─────────────────────────────────────────────────
+  # Load admin data split: full admin vs workspace owner
+  # ─────────────────────────────────────────────────
+
+  describe "admin data loading" do
+    setup %{conn: conn} do
+      admin = settings_user_fixture()
+      make_admin(admin)
+
+      %{conn: conn, admin: admin}
+    end
+
+    test "admin gets full admin data including user management", %{conn: conn, admin: admin} do
+      conn = log_in_settings_user(conn, admin)
+      {:ok, lv, _html} = live(conn, ~p"/settings/admin")
+
+      # Switch to users tab to verify user data was loaded
+      html = render_click(lv, "switch_admin_tab", %{"tab" => "users"})
+      assert html =~ "User Management"
+      assert html =~ admin.email
+    end
+
+    test "workspace owner gets integration settings but not user data", %{conn: conn} do
+      owner = settings_user_fixture() |> set_billing_role("owner")
+      conn = log_in_settings_user(conn, owner)
+
+      {:ok, _lv, html} = live(conn, ~p"/settings/admin")
+
+      # Owner should see integrations
+      assert html =~ "Integrations"
+
+      # But no user management (tab not even rendered)
+      refute html =~ "User Management"
+    end
+  end
+end

--- a/test/assistant_web/live/settings_live/profile_billing_test.exs
+++ b/test/assistant_web/live/settings_live/profile_billing_test.exs
@@ -30,7 +30,10 @@ defmodule AssistantWeb.SettingsLive.ProfileBillingTest do
         profile_form: to_form(socket.assigns.profile, as: :profile),
         billing_summary: socket.assigns.billing_summary,
         billing_storage: socket.assigns.billing_storage,
-        orchestrator_prompt_html: "<p>Prompt</p>"
+        orchestrator_prompt_html: "<p>Prompt</p>",
+        onboarding_checklist_items: [],
+        onboarding_all_complete?: true,
+        onboarding_dismissed?: true
       )
 
     assert html =~ "Workspace Billing"
@@ -66,7 +69,10 @@ defmodule AssistantWeb.SettingsLive.ProfileBillingTest do
           plan_note: "Manual override active.",
           metering_available?: true
         },
-        orchestrator_prompt_html: "<p>Prompt</p>"
+        orchestrator_prompt_html: "<p>Prompt</p>",
+        onboarding_checklist_items: [],
+        onboarding_all_complete?: true,
+        onboarding_dismissed?: true
       )
 
     assert html =~ "internal billing override"
@@ -106,7 +112,10 @@ defmodule AssistantWeb.SettingsLive.ProfileBillingTest do
           plan_note: "Free workspaces stop taking on new retained storage once they hit 25 MB.",
           metering_available?: true
         },
-        orchestrator_prompt_html: "<p>Prompt</p>"
+        orchestrator_prompt_html: "<p>Prompt</p>",
+        onboarding_checklist_items: [],
+        onboarding_all_complete?: true,
+        onboarding_dismissed?: true
       )
 
     assert html =~ "self-hosted"


### PR DESCRIPTION
## Summary
- Fix broken admin bootstrap flow — route guard now allows non-admins to claim admin when no admins exist
- Open integration configuration to workspace owners via `billing_role` (no full admin needed)
- Add centralized `can_configure_integrations?/1` helper on `Accounts.Scope`
- Gate admin sub-tabs by role: Integrations for workspace owners, Users/Models/Policies for admins only
- Add "Getting Started" onboarding checklist on Profile section (auto-hide + manual dismiss)
- Add `onboarding_dismissed_at` field and migration

## Test plan
- [ ] Unit tests for `Scope.can_configure_integrations?/1` (all role combos)
- [ ] Unit tests for `nav_items_for/1` (admin/owner/member filtering)
- [ ] Integration tests for route guard bootstrap exception
- [ ] Integration tests for workspace owner admin tab access
- [ ] Integration tests for onboarding checklist rendering and dismiss
- [ ] Verify fresh install bootstrap flow works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)